### PR TITLE
Fix: A bug on iPadOS type G but get H

### DIFF
--- a/Keyboard/iPad/MediumPadKeyboards/MediumPadCantoneseKeyboard.swift
+++ b/Keyboard/iPad/MediumPadKeyboards/MediumPadCantoneseKeyboard.swift
@@ -35,7 +35,7 @@ struct MediumPadCantoneseKeyboard: View {
                                         PadPullableInputKey(event: .letterS, upper: "#", lower: "s")
                                         PadPullableInputKey(event: .letterD, upper: "$", lower: "d")
                                         PadPullableInputKey(event: .letterF, upper: "/", lower: "f")
-                                        PadPullableInputKey(event: .letterH, upper: "（", lower: "g")
+                                        PadPullableInputKey(event: .letterG, upper: "（", lower: "g")
                                         PadPullableInputKey(event: .letterH, upper: "）", lower: "h")
                                         PadPullableInputKey(event: .letterJ, upper: "「", lower: "j")
                                         PadPullableInputKey(event: .letterK, upper: "」", lower: "k")


### PR DESCRIPTION
On iPadOS, in medium pad view, when typing g but it got h. It has been fixed.